### PR TITLE
修复导入路径 #31

### DIFF
--- a/src/Modules/EasyOC.RDBMS/Views/Admin/CreateOrEdit.cshtml
+++ b/src/Modules/EasyOC.RDBMS/Views/Admin/CreateOrEdit.cshtml
@@ -185,7 +185,7 @@
                 console.log("this.recipeText", this.recipeText)
                 this.loading = true; 
                 $.ajax({
-                    url: "@Href("~/api/RDBMS/ImportDeploymentPackage")",
+                    url: "@Href("~/api/ContentTypeManagement/ImportDeploymentPackage")",
                     type: "POST",
                     contentType: "application/json",//指定消息请求类型
                     data:JSON.stringify({


### PR DESCRIPTION
fix https://github.com/EasyOC/EasyOC/issues/31

updatecontenttype 生成失败 ，不存在对应/api/RDBMS/ImportDeploymentPackage 这个接口。
